### PR TITLE
Add a CSV exporter for the MetadataGuardian report

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -527,9 +527,9 @@ dependencies = [
 
 [[package]]
 name = "libz-sys"
-version = "1.1.3"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5435b8549c16d423ed0c03dbaafe57cf6c3344744f1242520d59c9d8ecec66"
+checksum = "6f35facd4a5673cb5a48822be2be1d4236c1c99cb4113cab7061ac720d5bf859"
 dependencies = [
  "cc",
  "libc",
@@ -693,9 +693,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.9.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
 name = "openssl-probe"
@@ -922,18 +922,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+checksum = "8380fe0152551244f0747b1bf41737e0f8a74f97a14ccefd1148187271634f3c"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1103,9 +1103,9 @@ dependencies = [
 
 [[package]]
 name = "termcolor"
-version = "1.1.2"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
 dependencies = [
  "winapi-util",
 ]
@@ -1196,9 +1196,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.22"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
+checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
 dependencies = [
  "lazy_static",
  "valuable",

--- a/python/examples/scan_external_sources_table.py
+++ b/python/examples/scan_external_sources_table.py
@@ -13,6 +13,7 @@ from metadata_guardian.source import (
     DeltaTableSource,
     GlueSource,
     KafkaSchemaRegistrySource,
+    MySQLSource,
     SnowflakeSource,
 )
 

--- a/python/examples/scan_local_sources.py
+++ b/python/examples/scan_local_sources.py
@@ -1,8 +1,20 @@
 import argparse
 import os
 
-from metadata_guardian import AvailableCategory, ColumnScanner, DataRules
-from metadata_guardian.source import AvroSource, ORCSource, ParquetSource
+from metadata_guardian import (
+    AvailableCategory,
+    ColumnScanner,
+    DataRules,
+    ExternalMetadataSource,
+)
+from metadata_guardian.source import (
+    AvroSource,
+    BigQuerySource,
+    DeltaTableSource,
+    KafkaSchemaRegistrySource,
+    ORCSource,
+    ParquetSource,
+)
 
 
 def get_gcp_bigquery() -> ExternalMetadataSource:

--- a/python/metadata_guardian/source/metadata_source.py
+++ b/python/metadata_guardian/source/metadata_source.py
@@ -29,9 +29,9 @@ class ColumnMetadata(Metadata):
 
         :return: a list of string
         """
-        yield self.column_name
+        yield self.column_name.lower()
         if self.column_comment:
-            yield self.column_comment
+            yield self.column_comment.lower()
 
 
 class MetadataSource(BaseModel, ABC):

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["maturin==0.12.9"]
+requires = ["maturin==0.12.10"]
 build-backend = "maturin"
 
 [project]

--- a/python/stubs/pyarrow/__init__.pyi
+++ b/python/stubs/pyarrow/__init__.pyi
@@ -1,4 +1,8 @@
 from typing import Any
 
 Schema: Any
+schema: Any
 cpu_count: Any
+string: Any
+Table: Any
+csv: Any


### PR DESCRIPTION
# Description
- Add a CSV exporter for the MetadataGuardian report
- Put in lowercase all the Metadata column_name and column_comments when searching